### PR TITLE
collections fileter v1.0

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -24,3 +24,4 @@ agnito:autogrow
 tkornblit:icheck
 jeremy:selectize
 monbro:iron-router-breadcrumb
+momentjs:moment

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -51,6 +51,7 @@ meteor-platform@1.2.2
 minifiers@1.1.5
 minimongo@1.0.8
 mobile-status-bar@1.0.3
+momentjs:moment@2.10.2
 monbro:iron-router-breadcrumb@1.0.7
 mongo@1.1.0
 mongo-livedata@1.0.8

--- a/client/templates/recheck/a-filter-collections-client.js
+++ b/client/templates/recheck/a-filter-collections-client.js
@@ -84,8 +84,6 @@ Meteor.FilterCollections = function (collection, settings) {
       }
 
       var query = self.query.get();
-      log('当前的query:');
-      log(query);
 
       if (_.isFunction(_callbacks.beforeSubscribe))
         query = _callbacks.beforeSubscribe(query) || query;
@@ -245,8 +243,6 @@ Meteor.FilterCollections = function (collection, settings) {
         offsetStart: offsetStart,
         offsetEnd: offsetEnd
       });
-      log('new pager');
-      log(_pager);
 
       if (triggerUpdate)
         this.run();
@@ -259,8 +255,7 @@ Meteor.FilterCollections = function (collection, settings) {
 
       _query.options.skip = _pager.offsetStart;
       _query.options.limit = _pager.itemsPerPage;
-      log('新的query');
-      log(_query);
+
       self.query.set(_query);
 
       return;
@@ -417,13 +412,10 @@ Meteor.FilterCollections = function (collection, settings) {
 
       if (!_.has(_filters, key))
         throw new Error("Filter Collection Error: " + key + " is not a valid filter.");
-      log(_filters[key]);
       _filters[key] = _.extend(_filters[key], filter);
-      log(_filters[key]);
       _filters[key].active = _filters[key].active ? false : true;
 
       if(triggerUpdate) {
-        log('run...');
         this.run();
       }
 
@@ -507,7 +499,6 @@ Meteor.FilterCollections = function (collection, settings) {
     },
     run: function(){
       _query.selector = this.getSelector();
-      log(_query.selector);
       self.query.set(_query);
       self.pager.moveTo(1);
 
@@ -651,14 +642,10 @@ Meteor.FilterCollections = function (collection, settings) {
       _deps.query.depend();
       var q = _.clone(_query);
       // q.options = _.omit(q.options, 'skip', 'limit');
-      log(q);
       if (_.isFunction(_callbacks.beforeResults))
         q = _callbacks.beforeResults(q) || q;
-      // log(q.options);
       var cursor = self._collection.find(q.selector, q.options);
-      log('新的查询结果：');
-      log(q);
-      log(cursor.fetch());
+
       if (_.isFunction(_callbacks.afterResults))
         cursor = _callbacks.afterResults(cursor) || cursor;
 
@@ -782,8 +769,6 @@ Meteor.FilterCollections = function (collection, settings) {
         if (alias)
           filter['alias'] = alias;
 
-        log(field);
-        log(filter);
         self.filter.set(field, filter);
       },
       'click .fc-filter-clear': function (event) {

--- a/client/templates/recheck/oplog_pk_list_filter.js
+++ b/client/templates/recheck/oplog_pk_list_filter.js
@@ -16,10 +16,10 @@ HomeFilter = new Meteor.FilterCollections(OplogPkList, {
       searchable: 'true'
     },
     "ts": {
-      title: 'Random Number',
+      title: '编辑时间',
       condition: '$and',
       transform: function (value) {
-        return parseFloat(value);
+        return parseInt(value);
       },
       sort: 'desc'
     },

--- a/client/templates/recheck/recheck.css
+++ b/client/templates/recheck/recheck.css
@@ -12,3 +12,17 @@
   border: solid 1px #ddd;
   float: right;
 }
+
+.recheck-filter-wrapper {
+    border-bottom: 1px solid #ccc;
+    padding-bottom: 3px;
+}
+
+.selected-filter-wrap {
+    padding-bottom: 3px;
+    border-bottom: 1px solid #ccc;
+}
+
+.recheck-itemlist-wrapper {
+    padding-top: 5px;
+}

--- a/client/templates/recheck/recheck.html
+++ b/client/templates/recheck/recheck.html
@@ -2,9 +2,9 @@
   <div class="recheck-page">
 
     <div class="recheck-left-wrapper">
-      <div class="recheck-filter-wrapper">
+      <div class="recheck-filter-wrapper" style="">
 
-        <strong>用户</strong>
+        <strong>用户:</strong>
         <br>
         {{#each editors}}
           <button href="# "
@@ -17,7 +17,8 @@
           </button>
         {{/each}}
         <br>
-        <strong>种类</strong>
+
+        <strong>数据类型:</strong>
         <br>
         {{#each collections}}
           <button href="# "
@@ -30,9 +31,25 @@
           </button>
         {{/each}}
 
-      <!-- 清除筛选 -->
         <br>
-        <strong>筛选条件</strong>
+        <strong>编辑时间:</strong>
+        <br>
+        {{#each timeLimits}}
+          <button href="# "
+            class="btn btn-default fc-filter"
+            data-fc-filter-field="ts"
+            data-fc-filter-value="{{timeLimit}}"
+            data-fc-filter-alias="{{name}}"
+            data-fc-filter-operator="{{operator}}"
+          >
+            {{name}}
+          </button>
+        {{/each}}
+      </div>
+
+      <!-- 清除筛选 -->
+      <div class="selected-filter-wrap">
+        <strong>筛选条件:</strong>
         <br>
         {{#each fcFilterActive}}
           <button href="#" class=" btn btn-default fc-filter-clear">
@@ -40,22 +57,24 @@
           </button>
         {{/each}}
         <br>
-        <button href="#" class="btn btn-default fc-filter-reset">清楚筛选</button>
+        <button href="#" class="btn btn-default fc-filter-reset">清空筛选条件</button>
       </div>
 
-      <div class="recheck-itemlist-wrapper">
+      <div class="recheck-itemlist-wrapper text-center">
         <div class="recheck-itemlist">
-          <ul class="list recheck-itemlist-ul">
+          <ul class="list recheck-itemlist-ul" style="padding: 0">
             {{#each fcResults}}
-              <li class="recheck-items list-group-item" id="{{pk}}">{{zhName}}<span class="badge">{{opCount}}</span></li>
+              <li class="recheck-items list-group-item" id="{{pk}}" data-ns="{{ns}}">{{zhName}}<span class="badge">{{opCount}}</span></li>
             {{/each}}
           </ul>
         </div>
       </div>
-      <div class="col-md-7 text-center">
+
+      <!-- 分页 -->
+      <div class="col-md-12 text-center">
         {{#if fcPager.pages}}
         <!-- numbered pager -->
-          <ul class="pagination">
+          <ul class="pagination pagination-sm">
             <li><a href="#" class="fc-pager-first">&lt;&lt;</a></li>
             <li><a href="#" class="fc-pager-previous">&lt;</a></li>
             {{#each fcPager.pages}}
@@ -64,7 +83,6 @@
             <li><a href="#" class="fc-pager-next">&gt;</a></li>
             <li><a href="#" class="fc-pager-last">&gt;&gt;</a></li>
           </ul>
-        <!-- /numbered pager -->
         {{/if}}
       </div>
     </div>

--- a/client/templates/recheck/recheck_ck.js
+++ b/client/templates/recheck/recheck_ck.js
@@ -1,10 +1,10 @@
 Template.recheck.onRendered(function(){
-  Session.set('recheckItem', undefined);
+  Session.set('recheckItem', {});
 });
 
 
 Template.recheck.helpers({
-  collections: function(){
+  collections: function() {
     return [
       {
         'conn': 'poi.ViewSpot',
@@ -28,20 +28,36 @@ Template.recheck.helpers({
       },
     ]
   },
-
-  // items: function(){
-  //   return [
-  //     {'pk': 1, 'zhName': 'Hello', 'opCount': 3},
-  //     {'pk': 2, 'zhName': 'World', 'opCount': 7}
-  //   ]
-  // }
+  timeLimits: function() {
+    return [
+      {
+        'timeLimit': moment().day(-3).unix() * 1000 + moment().milliseconds(),
+        'name': '最近三天',
+        'operator': '$gt'
+      },
+      {
+        'timeLimit': moment().day(-7).unix() * 1000 + moment().milliseconds(),
+        'name': '最近一周',
+        'operator': '$gt'
+      },
+      {
+        'timeLimit': moment().day(-14).unix() * 1000 + moment().milliseconds(),
+        'name': '最近两周',
+        'operator': '$gt'
+      }
+    ]
+  },
 });
-// Session.set('aizouTag', {});
 
 Template.recheck.events({
   'click .recheck-items': function(event, template) {
     var mid = $(event.target).attr('id');
-    // TODO 判断session的改变，触发helper运行
-
+    if(Session.get('recheckItem') && Session.get('recheckItem').pk === mid) {
+      return;
+    }
+    var ns = $(event.target).attr('data-ns');
+    Session.set('recheckItem', {'pk': mid, 'ns': ns});
+    log('当前的recheckItem Session');
+    log(Session.get('recheckItem'));
   },
 });

--- a/server/publications/a-filter-collections-server.js
+++ b/server/publications/a-filter-collections-server.js
@@ -23,9 +23,6 @@ Meteor.FilterCollections.publish = function (collection, options) {
     check(query, Object);
     var allow = true;
 
-    log('publish result query:');
-    log(query);
-
     if (callbacks.allow && _.isFunction(callbacks.allow))
       allow = callbacks.allow(query, this);
 
@@ -48,8 +45,6 @@ Meteor.FilterCollections.publish = function (collection, options) {
 
     var cursor = collection.find(query.selector, query.options);
 
-    log('publish results:');
-    log(cursor.fetch());
 
     if (callbacks.afterPublish && _.isFunction(callbacks.afterPublish))
       cursor = callbacks.afterPublish('results', cursor, this) || cursor;


### PR DESCRIPTION
主要功能：
- 筛选过滤（**编辑人员｜数据分类｜编辑时间**）
- 生成列表
- 分页

> 注：本功能修改自git代码：https://github.com/julianmontagna/filter-collections
> 由于该repo开发于meteor 0.7，现在的meteor已经update1.1，其中的一些代码兼容效果不好。最后通过阅读该repo的issue，综合几个可行的建议修改。

主要修改地方：
- 对`publish`的参数进行`check`；
- 将`Meteor.Collection` 改为 `Mongo.Collection`
-  `deps`加入`Iron.router`识别的`handle``
- 在一些`helper`和`event`上，加入`deps`的`depend`,使得其具有`reactive`性质

附带deps的说明，面向`Reactive Programming`:boom:：
https://manual.meteor.com/#deps
