### PR TITLE
fix display of selected pic

### DIFF
--- a/client/templates/data_review/picture/pictures.js
+++ b/client/templates/data_review/picture/pictures.js
@@ -19,7 +19,20 @@ function initial(){
   selectedCropHints = [];//记录原有已选图片的crophints
   upCropHints = [];//记录上传图片的crophints
   $('.selected-container').empty();
+  Session.set('selectedPicToCurSelected', []);
 };
+
+// 为搜索单个poi提供onRender监听
+Template.pictures.onRendered(function(){
+  var images = Session.get('selectedPicToCurSelected'),
+      parentDom = $('ul.selected-container')[0];
+
+  for (var i = 0, len = images.length; i < len; i++) {
+    Blaze.renderWithData(Template.selectedPicture, images[i], parentDom);
+  };
+  $('.selected-container').sortable().bind('sortupdate');
+})
+
 
 //可选图片模板
 Template.pictures.helpers({
@@ -95,6 +108,7 @@ Template.pictures.helpers({
       Blaze.renderWithData(Template.selectedPicture, image, $('ul.selected-container')[0]);
       $('.selected-container').sortable().bind('sortupdate');
     };
+    Session.set('selectedPicToCurSelected', images);
     return images;
   },
 


### PR DESCRIPTION
搜索界面之所以没有把已经存在的图片放入到已选图片，是因为`Blaze.renderWithData`的dom元素为空。在模板的helper中render数据到模板里，找不到dom，因为模板本身还在筹备数据。

编辑数据时，picture模版已经加载完毕，虽然**没有任何图片数据**，但是html dom结构已经出现在界面上。之后图片数据来了，可以用`Blaze.renderWithData(Template.selectedPicture, image, $('ul.selected-container')[0]);`动态加载已经存在的图片。
